### PR TITLE
feat: patchCompetition

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -114,7 +114,7 @@ jobs:
             echo "${{ secrets.DOCKERHUB_PASSWORD }}" >> ~/my_password.txt
             cat ~/my_password.txt | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
             docker pull ${{ secrets.DOCKERHUB_USERNAME }}/dias:latest
-            docker run -d -p 8080:8080 --env-file .env ${{ secrets.DOCKERHUB_USERNAME }}/dias:latest
+            docker run -d -p 8080:8080 -p 8001:8001 -p 8002:8002 --env-file .env ${{ secrets.DOCKERHUB_USERNAME }}/dias:latest
             y | docker rm $(docker ps -a -f status=exited -q)
             y | docker image prune
 

--- a/apps/admin-server/src/competition/competition.controller.ts
+++ b/apps/admin-server/src/competition/competition.controller.ts
@@ -119,6 +119,12 @@ export class CompetitionController implements ICompetitionController {
     @Param("id") id: string,
     @Body() request: PatchCompetitionRequestDto,
   ): Promise<Res<PatchCompetitionResponseDto>> {
-    throw new Error("Method not implemented.");
+    const data = await this.service.patchCompetition(id, request);
+
+    return {
+      data,
+      statusCode: 200,
+      statusMsg: ""
+    }
   }
 }

--- a/apps/admin-server/src/competition/competition.service.ts
+++ b/apps/admin-server/src/competition/competition.service.ts
@@ -125,6 +125,11 @@ export class CompetitionService implements ICompetitionService {
     id: string,
     request: PatchCompetitionRequestDto,
   ): Promise<PatchCompetitionResponseDto> {
-    throw new Error("Method not implemented.");
+    const thisComp = await this.prisma.findCompetitionById(id);
+    if (!thisComp) throw new NotFoundException();
+
+    await this.prisma.patchCompetition(id, request);
+
+    return { id };
   }
 }

--- a/apps/admin-server/src/competition/dto/request/patchCompetition.request.dto.ts
+++ b/apps/admin-server/src/competition/dto/request/patchCompetition.request.dto.ts
@@ -36,18 +36,4 @@ export class PatchCompetitionRequestDto {
   @IsOptional()
   @IsString()
   place?: string;
-
-  @IsOptional()
-  @IsArray()
-  awards?: Awards[];
-}
-
-class Awards {
-  @IsOptional()
-  @IsString()
-  name?: string;
-
-  @IsOptional()
-  @IsNumber()
-  count?: number;
 }

--- a/apps/admin-server/src/competition/test/competition.controller.spec.ts
+++ b/apps/admin-server/src/competition/test/competition.controller.spec.ts
@@ -8,6 +8,7 @@ import { BadRequestException, Logger } from "@nestjs/common";
 import { PostCompetitionRequestDto } from "../dto/request/postCompetition.request.dto";
 import { PostAwardsRequestDto } from "../dto/request/postAwards.request.dto";
 import { COMPETITION_STATUS } from "../../prisma/client";
+import { PatchCompetitionRequestDto } from "../dto/request/patchCompetition.request.dto";
 
 describe("CompetitionController", () => {
   let controller: CompetitionController;
@@ -48,6 +49,11 @@ describe("CompetitionController", () => {
         audience: "대전 소재 고등학교 1 ~ 2학년에 재학중인 학생",
         place: "대덕소프트웨어마이스터고등학교",
         status: COMPETITION_STATUS.ONGOING,
+      };
+    }),
+    patchCompetition: jest.fn(() => {
+      return {
+        id: "1",
       };
     }),
   };
@@ -204,6 +210,32 @@ describe("CompetitionController", () => {
         new BadRequestException("Must included parameter as id"),
       );
       expect(serviceMock.getCompetition).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe("PatchCompetition", () => {
+    const id = "1";
+    const request: PatchCompetitionRequestDto = {
+      name: "대덕소프트웨어마이스터고등학교 전국 중학생 알고리즘 대회",
+      status: "ONGOING",
+      startDate: "2024-08-27T00:00:00.000Z",
+      endDate: "2024-08-30T23:59:59.000Z",
+      purpose:
+        "학생들의 알고리즘 풀이 능력 향상 및 중학생 대상으로 본교 홍보",
+      audience: "전국 중학생 중 본 대회의 예선 통과자",
+      place: "대덕소프트웨어마이스터고등학교 소프트웨어개발 1 ~ 3실",
+    }
+    it("[200] update all", async () => {
+      const res = await controller.patchCompetition(id, request);
+      expect(res).toEqual({
+        data: {
+          id: "1",
+        },
+        statusCode: 200,
+        statusMsg: ""
+      })
+      expect(serviceMock.patchCompetition).toHaveBeenCalledTimes(1);
+      expect(serviceMock.patchCompetition).toHaveBeenCalledWith(id, request);
     });
   });
 });

--- a/apps/admin-server/src/prisma/prisma.service.ts
+++ b/apps/admin-server/src/prisma/prisma.service.ts
@@ -8,7 +8,7 @@ import {
   OnModuleInit,
 } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
-import { PrismaClient } from "./client";
+import { COMPETITION_STATUS, PrismaClient } from "./client";
 
 @Injectable()
 export class PrismaService
@@ -195,6 +195,45 @@ export class PrismaService
         },
         data: {
           is_active: !thisClub.is_active,
+        },
+      });
+    } catch (e) {
+      this.logger.error(e);
+      throw new InternalServerErrorException(e);
+    }
+  }
+
+  async patchCompetition(
+    id: string,
+    obj: {
+      name?: string;
+      status?: COMPETITION_STATUS;
+      startDate?: string;
+      endDate?: string;
+      purpose?: string;
+      audience?: string;
+      place?: string;
+    },
+  ) {
+    try {
+      const thisComp = await this.contests.findUnique({
+        where: {
+          id,
+        },
+      });
+
+      await this.contests.update({
+        where: {
+          id,
+        },
+        data: {
+          name: obj.name ?? thisComp.name,
+          status: obj.status ?? thisComp.status,
+          start_date: new Date(obj.startDate ?? thisComp.start_date),
+          end_date: new Date(obj.endDate ?? thisComp.end_date),
+          purpose: obj.purpose ?? thisComp.purpose,
+          audience: obj.audience ?? thisComp.audience,
+          place: obj.place ?? thisComp.place,
         },
       });
     } catch (e) {

--- a/apps/admin-server/src/prisma/prisma.service.ts
+++ b/apps/admin-server/src/prisma/prisma.service.ts
@@ -216,25 +216,27 @@ export class PrismaService
     },
   ) {
     try {
-      const thisComp = await this.contests.findUnique({
-        where: {
-          id,
-        },
-      });
+      await this.$transaction(async (prisma) => {
+        const thisComp = await this.contests.findUnique({
+          where: {
+            id,
+          },
+        });
 
-      await this.contests.update({
-        where: {
-          id,
-        },
-        data: {
-          name: obj.name ?? thisComp.name,
-          status: obj.status ?? thisComp.status,
-          start_date: new Date(obj.startDate ?? thisComp.start_date),
-          end_date: new Date(obj.endDate ?? thisComp.end_date),
-          purpose: obj.purpose ?? thisComp.purpose,
-          audience: obj.audience ?? thisComp.audience,
-          place: obj.place ?? thisComp.place,
-        },
+        await this.contests.update({
+          where: {
+            id,
+          },
+          data: {
+            name: obj.name ?? thisComp.name,
+            status: obj.status ?? thisComp.status,
+            start_date: new Date(obj.startDate ?? thisComp.start_date),
+            end_date: new Date(obj.endDate ?? thisComp.end_date),
+            purpose: obj.purpose ?? thisComp.purpose,
+            audience: obj.audience ?? thisComp.audience,
+            place: obj.place ?? thisComp.place,
+          },
+        });
       });
     } catch (e) {
       this.logger.error(e);


### PR DESCRIPTION
# 변경 타입

- [ ] 버그 수정 (충돌이 없는 순수한 오류 수정)
- [x] 새로운 기능 (충돌이 발생하지 않는 기능 추가)
- [x] 변경점 발생 (기존의 기능이 의도대로 동작하지 않거나 삭제되었을 수 있음)
- [ ] 문서 변경

<br/>

# 요약

- prod 브랜치로 배포 시 `admin-server`와 `asset-server`의 외부 포팅
- `patchCompetition` 기능 추가 및 테스트

- 변경 사항 :
- 관련 이슈 : 
- 배경 : 
- 종속성 변경 :


<br/>

# 테스트

- 테스트 시간이 예상보다 더 길게 나타남
- 추후 수정 필요

- [x] 단위 테스트
- [ ] 통합 테스트

<br/>

**Test Configuration**:
* 펌웨어 버전 :
* 하드웨어 :
* 툴체인:
* SDK:

# Checklist:

- [x] 코드가 프로젝트의 명명 규칙을 따릅니다
- [x] 자체적으로 검토를 진행하였습니다.
- [ ] 다른 기여자가 이해하기 어려울 코드에 주석을 달아 설명하였습니다.
- [ ] 문서와 변경점을 동기화하였습니다.
- [ ] 이 PR의 변경사항으로 인한 새로운 경고가 발생하지 않습니다.
- [x] 내 수정 사항이 효과적이거나 기능이 작동한다는 것을 증명하는 테스트를 추가했습니다.
- [x] 새 단위 테스트 및 기존 단위 테스트가 내 변경 사항과 함께 로컬에서 통과됨을 확인하였습니다.
- [ ] 모든 종속 변경 사항이 병합되어 다운스트림 모듈에 게시되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- 경쟁 데이터의 패치 요청을 처리할 수 있는 기능 추가.
	- Docker 컨테이너의 포트 매핑 확장으로 접근성 향상.

- **Bug Fixes**
	- 패치 요청 처리 시 오류 처리 로직 추가로 안정성 향상.

- **Tests**
	- 경쟁 패치 기능에 대한 테스트 케이스 추가로 테스트 범위 확장.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->